### PR TITLE
add javascript code highlighting in zh/Modify-the-open-source-project.md

### DIFF
--- a/zh/Modify-the-open-source-project.md
+++ b/zh/Modify-the-open-source-project.md
@@ -27,7 +27,7 @@
 每次出来的方块，的确是朝代名称了，但是加在一起之后，却全都变成了2。
 
 还是在game_manager.js，我们发现了如下一段代码：
-
+```javascript
     var merged = new Tile(positions.next, tile.value * 2);
     merged.mergedFrom = [tile, next];
     
@@ -42,18 +42,18 @@
     
     // The mighty 2048 tile
     if (merged.value === 2048) self.won = true;
-    
+```    
 看来这就是我们要修改的关键所在了。`tile.value`的值现在是一个字符串，所以不能简单的乘以2，我们可以先找到它在NameArray里的位置，然后取它的下一个值。
-
+```javascript
     var pos =NameArray.indexOf(tile.value);
     var merged = new Tile(positions.next, NameArray[pos+1]);
-
+```
 另外，`merged.value`也不能直接加到`self.score`里去了，要改成:
-
+```javascript
     now_value=Math.pow(2,pos+2);
     self.score += now_value;
     if (now_value === 2048) self.won = true;
-    
+```    
 再运行一下看看，发现了一些丑陋的bug。
 ![](images/2048-2.png)
 
@@ -68,14 +68,14 @@
 在html_actuator.js中，我们找到了这样一句： `var classes = ["tile", "tile-" + tile.value, positionClass];`
 
 我们可以在这一行的前面，补上两句：
-
+```javascript
     var pos =NameArray.indexOf(tile.value);
     var tile_value=Math.pow(2,pos+1);
     //再修改一下刚才的那句：
     var classes = ["tile", "tile-" + tile_value, positionClass];
-    
+```    
 于是，正常的颜色就会出现了。至于字体大小的问题，我们得回到main.css中去找答案。
-
+```javascript
     .tile .tile-inner {
       border-radius: 3px;
       background: #eee4da;
@@ -83,7 +83,7 @@
       font-weight: bold;
       z-index: 10;
       font-size: 55px; }
-
+```
 我们可以简单粗暴将`font-size: 55px;`，改成`font-size: 35px;`。我们看一下现在的效果：
 ![](images/2048-4.png)
 


### PR DESCRIPTION
* 在zh/Modify-the-open-source-project.md里增加了javascript代码样式，使其支持语法高亮。
更改后的文档渲染样式示例如下：
```javascript
    var pos =NameArray.indexOf(tile.value);
    var merged = new Tile(positions.next, NameArray[pos+1]);
```

